### PR TITLE
tests: allow running integration tests against a custom simulator

### DIFF
--- a/README-rust.md
+++ b/README-rust.md
@@ -9,3 +9,21 @@ To run the example:
     cargo run --example singlethreaded --features=usb,tokio/rt,tokio/macros
 
 See [Cargo.toml](Cargo.toml) for further examples.
+
+## Simulator tests
+
+tests/simulator_tests.rs runs a set of integration tests against BitBox02 simulators. They are
+automatically downloaded based on [tests/simulators.json](tests/simulators.json), and each one is
+tested with.
+
+To run them, use:
+
+    cargo test --features=simulator,tokio
+
+If you want to test against a custom simulator build (e.g. when developing new firmware features),
+you can run:
+
+    SIMULATOR=/path/to/simulator cargo test --features=simulator,tokio
+
+In this case, only the given simulator will be used, and the ones defined in simulators.json will be
+ignored.

--- a/tests/simulator_tests.rs
+++ b/tests/simulator_tests.rs
@@ -202,7 +202,11 @@ async fn test_btc(bitbox: &PairedBitBox) {
 
 #[tokio::test]
 async fn test_device() {
-    let simulator_filenames = download_simulators().await.unwrap();
+    let simulator_filenames = if let Some(simulator_filename) = option_env!("SIMULATOR") {
+        vec![simulator_filename.into()]
+    } else {
+        download_simulators().await.unwrap()
+    };
     for simulator_filename in simulator_filenames {
         {
             println!("Simulator tests using {}", simulator_filename);


### PR DESCRIPTION
For convenience. Useful to test simulators of upcoming firmware releases or local custom simulator builds.