### PR TITLE
btc: support Taproot policies

### DIFF
--- a/CHANGELOG-npm.md
+++ b/CHANGELOG-npm.md
@@ -5,6 +5,7 @@
 ## 0.7.0
 - btc: handle error when an input's previous transaction is required but missing
 - btc: add support for regtest
+- btc: add support for Taproot wallet policies
 
 ## 0.6.0
 

--- a/CHANGELOG-rust.md
+++ b/CHANGELOG-rust.md
@@ -5,6 +5,7 @@
 ## 0.6.0
 - btc: handle error when an input's previous transaction is required but missing
 - btc: add support for regtest
+- btc: add support for Taproot wallet policies
 - cardano: added support for vote delegation
 
 ## 0.5.0

--- a/tests/simulators.json
+++ b/tests/simulators.json
@@ -2,5 +2,13 @@
     {
         "url": "https://github.com/BitBoxSwiss/bitbox02-firmware/releases/download/firmware%2Fv9.19.0/bitbox02-multi-v9.19.0-simulator1.0.0-linux-amd64",
         "sha256": "e28be3fd6c7777624ad2574546ba125b7f134f095fa951acc8fb7295f3d33931"
+    },
+    {
+        "url": "https://github.com/BitBoxSwiss/bitbox02-firmware/releases/download/firmware%2Fv9.20.0/bitbox02-multi-v9.20.0-simulator1.0.0-linux-amd64",
+        "sha256": "ac32c1a71bd0a3a934bc7b94268f651c655f2e3afbb954811a256e551a420b3d"
+    },
+    {
+        "url": "https://github.com/BitBoxSwiss/bitbox02-firmware/releases/download/firmware%2Fv9.21.0/bitbox02-multi-v9.21.0-simulator1.0.0-linux-amd64",
+        "sha256": "72031b226ea344970a6a1506893838a63b075e0bad726557ab9d941b42c534f5"
     }
 ]


### PR DESCRIPTION
This mostly involves fixing PSBT signing to be able to handle Taproot leaf script spends.

Integration tests with the simulator are added. The signed PSBTs are checked to be correctly signed by rust-miniscript and rust-bitcoinconsensus.