### PR TITLE
ci: remove actions using Rust nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,28 +45,6 @@ jobs:
           sudo apt-get install -y libudev-dev
           ./ci.sh
 
-
-  Nightly:
-    name: Test - nightly toolchain
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: clippy, rustfmt
-      - name: Enable simulators caching
-        uses: actions/cache@v4
-        with:
-          key: ${{runner.os}}-simulators-cache-${{hashFiles('./tests/simulators.json')}}
-          path: |
-            ./tests/simulators
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y libudev-dev
-          ./ci.sh
-
   WASM:
     name: WASM and Sandbox
     runs-on: ubuntu-latest


### PR DESCRIPTION
Nightly quite often breaks CI by introducing new clippy linters etc, which disrupts one's work when one wants to land a PR whose CI suddenly fails for unrelated reasons.

Sometimes, the new linters are also broken and result in false positives. The one that prompted this commit is a false positive about needless_return like this:
https://github.com/rust-lang/rust-clippy/issues/13526

```
error: unneeded `return` statement
   --> tests/simulator_tests.rs:212:51
    |
212 |       for simulator_filename in simulator_filenames {
    |  ___________________________________________________^
213 | |         println!("Simulator tests using {}", simulator_filename);
214 | |         let _server = Server::launch(&simulator_filename);
...   |
244 | |         test_btc(&paired_bitbox).await
245 | |     }
```

(there is no return statement)