### PR TITLE
eth: fix clippy error

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -363,7 +363,7 @@ fn get_value(
         HashMap(&'a HashMap<String, Value>),
         JsonValue(Value),
     }
-    impl<'a> Either<'a> {
+    impl Either<'_> {
         fn get(&self, key: &str) -> Option<&Value> {
             match self {
                 Either::HashMap(map) => map.get(key),


### PR DESCRIPTION
```
error: the following explicit lifetimes could be elided: 'a
   --> src/eth.rs:366:10
    |
366 |     impl<'a> Either<'a> {
    |          ^^         ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
    |
366 -     impl<'a> Either<'a> {
366 +     impl Either<'_> {
```