### PR TITLE
add `features()` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,13 @@ pub struct BitBox<R: Runtime> {
 
 pub type PairingCode = String;
 
+#[cfg_attr(feature = "wasm", serde(rename_all = "camelCase"))]
+/// A list of features supported by the currently connected BitBox.
+pub struct Features {
+    /// Can use `tag_cbor_sets` in `cardano_sign_transaction()`.
+    pub cardano_tag_cbor_sets: bool,
+}
+
 impl<R: Runtime> BitBox<R> {
     async fn from(
         device: Box<dyn communication::ReadWrite>,
@@ -349,6 +356,16 @@ impl<R: Runtime> PairedBitBox<R> {
     /// Returns the firmware version.
     pub fn version(&self) -> &semver::Version {
         &self.communication.info.version
+    }
+
+    /// Returns list of features supported by the currently connected BitBox.
+    pub fn features(&self) -> Features {
+        let version = self.version();
+        let version_at_least =
+            |major, minor, patch| *version >= semver::Version::new(major, minor, patch);
+        Features {
+            cardano_tag_cbor_sets: version_at_least(9, 22, 0),
+        }
     }
 
     /// Returns the hex-encoded 4-byte root fingerprint.

--- a/tests/test_cardano.rs
+++ b/tests/test_cardano.rs
@@ -397,6 +397,7 @@ async fn test_cardano_transactions() {
                 .unwrap()
                 .matches(bitbox.version())
             {
+                assert!(bitbox.features().cardano_tag_cbor_sets);
                 let witness = bitbox.cardano_sign_transaction(transaction).await.unwrap();
                 assert_eq!(witness.shelley_witnesses.len(), 1);
                 assert_eq!(
@@ -404,6 +405,7 @@ async fn test_cardano_transactions() {
                     "6b5d4134cfc66281827d51cb0196f1a951ce168c19ba1314233f43d39d91e2bc",
                 );
             } else {
+                assert!(!bitbox.features().cardano_tag_cbor_sets);
                 assert!(matches!(
                     bitbox.cardano_sign_transaction(transaction).await,
                     Err(bitbox_api::error::Error::Version(">=9.22.0"))


### PR DESCRIPTION
Helpful if clients want to conditionally make use of features without users running into a firmware version error.