### PR TITLE
webhid: avoid unecessary device selection prompt if device already connected

### DIFF
--- a/webhid.js
+++ b/webhid.js
@@ -36,7 +36,14 @@ class MessageQueue {
 export async function getWebHIDDevice(vendorId, productId, onCloseCb) {
   let device;
   try {
-    const devices = await navigator.hid.requestDevice({filters: [{vendorId, productId}]});
+    // Try to get directly the device. This will work without prompting user
+    // permission if it has already been validated before on the current website.
+    let devices = await navigator.hid.getDevices({filters: [{vendorId, productId}]});
+    if (devices.length == 0){
+      // If direct access failed, which happen for new websites, ask user
+      // confirmation.
+      devices = await navigator.hid.requestDevice({filters: [{vendorId, productId}]});
+    }
     const d = devices[0];
     // Filter out other products that might be in the list presented by the Browser.
     if (d.productName.includes('BitBox02')) {


### PR DESCRIPTION
Motivation: if connecting through webhid, browser keeps showing prompt to select device even though the device has already been paired. This PR fixes that behavior and reuses existing pairing, avoiding the redundant prompt.

Ledger js library works similarly:

https://github.com/LedgerHQ/ledger-live/blob/a77b0c1236302f4fb58b61cf7d0df5632cdc86e1/libs/ledgerjs/packages/hw-transport-webhid/src/TransportWebHID.ts#L110

https://github.com/LedgerHQ/ledger-live/blob/a77b0c1236302f4fb58b61cf7d0df5632cdc86e1/libs/ledgerjs/packages/hw-transport/src/Transport.ts#L295