### PR TITLE
fix multithreaded+simulator combination

### DIFF
--- a/CHANGELOG-rust.md
+++ b/CHANGELOG-rust.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Add `bip85_app_bip39()`
+- Make the `simulator` feature work with the `multithreaded` feature
 
 ## 0.7.0
 - cardano: add support for 258-tagged sets

--- a/CHANGELOG-rust.md
+++ b/CHANGELOG-rust.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 0.8.0
 - Add `bip85_app_bip39()`
 - Make the `simulator` feature work with the `multithreaded` feature
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,10 @@ required-features = ["usb", "tokio/rt", "tokio/macros", "rlp"]
 name = "cardano"
 required-features = ["usb", "tokio/rt", "tokio/macros"]
 
+[[example]]
+name = "simulator"
+required-features = ["simulator", "tokio/rt", "tokio/macros", "tokio/rt-multi-thread", "multithreaded"]
+
 [profile.release]
 # Reduce wasm binary size.
 opt-level = 'z'

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ example-eth:
 	cargo run --example eth --features=usb,tokio/rt,tokio/macros,rlp
 example-cardano:
 	cargo run --example cardano --features=usb,tokio/rt,tokio/macros
+example-simulator:
+	cargo run --example simulator --features=simulator,tokio/rt,tokio/macros,tokio/rt-multi-thread,multithreaded
 wasm:
 	wasm-pack build --release --features=wasm
 	cp webhid.js pkg/

--- a/examples/simulator.rs
+++ b/examples/simulator.rs
@@ -1,0 +1,17 @@
+async fn demo<R: bitbox_api::runtime::Runtime + Sync + Send>() {
+    let noise_config = Box::new(bitbox_api::NoiseConfigNoCache {});
+    let bitbox = bitbox_api::BitBox::<R>::from_simulator(None, noise_config)
+        .await
+        .unwrap();
+    let pairing_bitbox = bitbox.unlock_and_pair().await.unwrap();
+    let paired_bitbox = pairing_bitbox.wait_confirm().await.unwrap();
+    println!(
+        "device info: {:?}",
+        paired_bitbox.device_info().await.unwrap()
+    );
+}
+
+#[tokio::main]
+async fn main() {
+    demo::<bitbox_api::runtime::TokioRuntime>().await
+}

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -42,7 +42,8 @@ pub async fn try_connect<R: Runtime>(endpoint: Option<&str>) -> Result<Box<TcpCl
 
 impl crate::util::Threading for TcpClient {}
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "multithreaded", async_trait)]
+#[cfg_attr(not(feature="multithreaded"), async_trait(?Send))]
 impl ReadWrite for TcpClient {
     fn write(&self, msg: &[u8]) -> Result<usize, CommunicationError> {
         let mut stream = self.stream.lock().unwrap();


### PR DESCRIPTION
We only added the simulator feature for the unti tests, which run in a single thread. This adds support for using the simulator function with the multithreaded feature.