### PR TITLE
fix: use variables directly in `format!` string

### DIFF
--- a/examples/btc_miniscript.rs
+++ b/examples/btc_miniscript.rs
@@ -12,7 +12,7 @@ async fn get_bitbox02() -> bitbox_api::PairedBitBox<bitbox_api::runtime::TokioRu
     .unwrap();
     let pairing_bitbox = bitbox.unlock_and_pair().await.unwrap();
     if let Some(pairing_code) = pairing_bitbox.get_pairing_code().as_ref() {
-        println!("Pairing code\n{}", pairing_code);
+        println!("Pairing code\n{pairing_code}");
     }
     pairing_bitbox.wait_confirm().await.unwrap()
 }

--- a/examples/btc_sign_msg.rs
+++ b/examples/btc_sign_msg.rs
@@ -10,7 +10,7 @@ async fn signmsg<R: bitbox_api::runtime::Runtime>() {
     .unwrap();
     let pairing_bitbox = bitbox.unlock_and_pair().await.unwrap();
     if let Some(pairing_code) = pairing_bitbox.get_pairing_code().as_ref() {
-        println!("Pairing code\n{}", pairing_code);
+        println!("Pairing code\n{pairing_code}");
     }
     let paired_bitbox = pairing_bitbox.wait_confirm().await.unwrap();
 
@@ -27,7 +27,7 @@ async fn signmsg<R: bitbox_api::runtime::Runtime>() {
         .btc_sign_message(pb::BtcCoin::Btc, script_config_sign_msg, b"message")
         .await
         .unwrap();
-    println!("Signature: {:?}", signature);
+    println!("Signature: {signature:?}");
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/examples/btc_sign_psbt.rs
+++ b/examples/btc_sign_psbt.rs
@@ -11,7 +11,7 @@ async fn sign_psbt<R: bitbox_api::runtime::Runtime>(psbt: &mut bitcoin::psbt::Ps
     .unwrap();
     let pairing_device = d.unlock_and_pair().await.unwrap();
     if let Some(pairing_code) = pairing_device.get_pairing_code().as_ref() {
-        println!("Pairing code\n{}", pairing_code);
+        println!("Pairing code\n{pairing_code}");
     }
     let paired = pairing_device.wait_confirm().await.unwrap();
     paired
@@ -33,5 +33,5 @@ async fn main() {
     let mut psbt = bitcoin::psbt::Psbt::from_str(buffer.trim()).unwrap();
     sign_psbt::<bitbox_api::runtime::TokioRuntime>(&mut psbt).await;
     println!("signed:");
-    println!("{}", psbt);
+    println!("{psbt}");
 }

--- a/examples/btc_signtx.rs
+++ b/examples/btc_signtx.rs
@@ -10,7 +10,7 @@ async fn signtx<R: bitbox_api::runtime::Runtime>() {
     .unwrap();
     let pairing_bitbox = bitbox.unlock_and_pair().await.unwrap();
     if let Some(pairing_code) = pairing_bitbox.get_pairing_code().as_ref() {
-        println!("Pairing code\n{}", pairing_code);
+        println!("Pairing code\n{pairing_code}");
     }
     let paired_bitbox = pairing_bitbox.wait_confirm().await.unwrap();
 

--- a/examples/cardano.rs
+++ b/examples/cardano.rs
@@ -10,7 +10,7 @@ async fn demo<R: bitbox_api::runtime::Runtime>() {
     .unwrap();
     let pairing_bitbox = bitbox.unlock_and_pair().await.unwrap();
     if let Some(pairing_code) = pairing_bitbox.get_pairing_code().as_ref() {
-        println!("Pairing code\n{}", pairing_code);
+        println!("Pairing code\n{pairing_code}");
     }
     let paired_bitbox = pairing_bitbox.wait_confirm().await.unwrap();
 
@@ -22,7 +22,7 @@ async fn demo<R: bitbox_api::runtime::Runtime>() {
         ])
         .await
         .unwrap();
-    println!("Xpubs: {:?}", xpubs);
+    println!("Xpubs: {xpubs:?}");
 
     println!("Getting an address...");
     let address = paired_bitbox
@@ -36,7 +36,7 @@ async fn demo<R: bitbox_api::runtime::Runtime>() {
         )
         .await
         .unwrap();
-    println!("Address: {}", address);
+    println!("Address: {address}");
 
     println!("Signing a transaction with tokens...");
     let change_config = bitbox_api::cardano::make_script_config_pkh_skh(
@@ -101,7 +101,7 @@ async fn demo<R: bitbox_api::runtime::Runtime>() {
         .cardano_sign_transaction(transaction)
         .await
         .unwrap();
-    println!("Witness: {:?}", witness);
+    println!("Witness: {witness:?}");
 
     println!("Delegating to a staking pool...");
     let transaction = pb::CardanoSignTransactionRequest {
@@ -156,7 +156,7 @@ async fn demo<R: bitbox_api::runtime::Runtime>() {
         .cardano_sign_transaction(transaction)
         .await
         .unwrap();
-    println!("Witness: {:?}", witness);
+    println!("Witness: {witness:?}");
 
     println!("Withdrawing staking rewards...");
     let transaction = pb::CardanoSignTransactionRequest {
@@ -194,7 +194,7 @@ async fn demo<R: bitbox_api::runtime::Runtime>() {
         .cardano_sign_transaction(transaction)
         .await
         .unwrap();
-    println!("Witness: {:?}", witness);
+    println!("Witness: {witness:?}");
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/examples/eth.rs
+++ b/examples/eth.rs
@@ -56,7 +56,7 @@ async fn eth_demo<R: bitbox_api::runtime::Runtime>() {
     .unwrap();
     let pairing_bitbox = bitbox.unlock_and_pair().await.unwrap();
     if let Some(pairing_code) = pairing_bitbox.get_pairing_code().as_ref() {
-        println!("Pairing code\n{}", pairing_code);
+        println!("Pairing code\n{pairing_code}");
     }
     let paired_bitbox = pairing_bitbox.wait_confirm().await.unwrap();
 
@@ -65,14 +65,14 @@ async fn eth_demo<R: bitbox_api::runtime::Runtime>() {
         .eth_xpub(&"m/44'/60'/0'/0".try_into().unwrap())
         .await
         .unwrap();
-    println!("Xpub: {}", xpub);
+    println!("Xpub: {xpub}");
 
     println!("Verifying address...");
     let address = paired_bitbox
         .eth_address(1, &"m/44'/60'/0'/0/0".try_into().unwrap(), true)
         .await
         .unwrap();
-    println!("Address: {}", address);
+    println!("Address: {address}");
 
     println!("Signing a tx...");
     let raw_tx = hex::decode("f86e821fdc850165a0bc008252089404f264cf34440313b4a0192a352814fbe927b88588075cf1259e9c40008025a015c94c1a3da0abc0a9124d2837809ccc493c41504e4571bcc340eeb68a91f641a03599011d4cda2c33dd3b00071ec145335e5d2dd5ed812d5eebeecba5264ed1bf").unwrap();

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -10,7 +10,7 @@ async fn demo<R: bitbox_api::runtime::Runtime + Sync + Send>() {
     .unwrap();
     let pairing_bitbox = bitbox.unlock_and_pair().await.unwrap();
     if let Some(pairing_code) = pairing_bitbox.get_pairing_code().as_ref() {
-        println!("Pairing code\n{}", pairing_code);
+        println!("Pairing code\n{pairing_code}");
     }
     multithreading_type_check(&pairing_bitbox);
     let paired_bitbox = pairing_bitbox.wait_confirm().await.unwrap();

--- a/examples/singlethreaded.rs
+++ b/examples/singlethreaded.rs
@@ -8,7 +8,7 @@ async fn demo<R: bitbox_api::runtime::Runtime>() {
     .unwrap();
     let pairing_bitbox = bitbox.unlock_and_pair().await.unwrap();
     if let Some(pairing_code) = pairing_bitbox.get_pairing_code().as_ref() {
-        println!("Pairing code\n{}", pairing_code);
+        println!("Pairing code\n{pairing_code}");
     }
     let paired_bitbox = pairing_bitbox.wait_confirm().await.unwrap();
     println!(

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -205,10 +205,10 @@ fn parse_type(
     if typ.ends_with(']') {
         let index = typ
             .rfind('[')
-            .ok_or(format!("Invalid type format: {}", typ))?;
+            .ok_or(format!("Invalid type format: {typ}"))?;
         let (rest, size) = (&typ[..index], &typ[index + 1..typ.len() - 1]);
         let size_int = if !size.is_empty() {
-            u32::from_str(size).map_err(|e| format!("Error parsing size: {}", e))?
+            u32::from_str(size).map_err(|e| format!("Error parsing size: {e}"))?
         } else {
             0
         };
@@ -221,7 +221,7 @@ fn parse_type(
         })
     } else if let Some(size) = typ.strip_prefix("bytes") {
         let size_int = if !size.is_empty() {
-            u32::from_str(size).map_err(|e| format!("Error parsing size: {}", e))?
+            u32::from_str(size).map_err(|e| format!("Error parsing size: {e}"))?
         } else {
             0
         };
@@ -235,7 +235,7 @@ fn parse_type(
         if size.is_empty() {
             return Err("uint must be sized".to_string());
         }
-        let size_int = u32::from_str(size).map_err(|e| format!("Error parsing size: {}", e))? / 8;
+        let size_int = u32::from_str(size).map_err(|e| format!("Error parsing size: {e}"))? / 8;
         Ok(MemberType {
             r#type: DataType::Uint.into(),
             size: size_int,
@@ -246,7 +246,7 @@ fn parse_type(
         if size.is_empty() {
             return Err("int must be sized".to_string());
         }
-        let size_int = u32::from_str(size).map_err(|e| format!("Error parsing size: {}", e))? / 8;
+        let size_int = u32::from_str(size).map_err(|e| format!("Error parsing size: {e}"))? / 8;
         Ok(MemberType {
             r#type: DataType::Int.into(),
             size: size_int,
@@ -282,7 +282,7 @@ fn parse_type(
             array_type: None,
         })
     } else {
-        Err(format!("Can't recognize type: {}", typ))
+        Err(format!("Can't recognize type: {typ}"))
     }
 }
 
@@ -303,7 +303,7 @@ fn encode_value(typ: &MemberType, value: &Value) -> Result<Vec<u8>, String> {
             Value::String(v) => {
                 if v.starts_with("0x") || v.starts_with("0X") {
                     Ok(BigUint::parse_bytes(&v.as_bytes()[2..], 16)
-                        .ok_or(format!("could not parse {} as hex", v))?
+                        .ok_or(format!("could not parse {v} as hex"))?
                         .to_bytes_be())
                 } else {
                     Ok(BigUint::from_str(v)

--- a/src/wasm/types.rs
+++ b/src/wasm/types.rs
@@ -330,7 +330,7 @@ impl TryFrom<TsCardanoTransaction> for crate::pb::CardanoSignTransactionRequest 
 
     fn try_from(value: TsCardanoTransaction) -> Result<Self, Self::Error> {
         serde_wasm_bindgen::from_value(value.into())
-            .map_err(|e| JavascriptError::Foo(format!("wrong type for CardanoTransaction {:?}", e)))
+            .map_err(|e| JavascriptError::Foo(format!("wrong type for CardanoTransaction {e:?}")))
     }
 }
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -58,8 +58,8 @@ impl Server {
             let reader = std::io::BufReader::new(stdout);
             for line in reader.lines() {
                 match line {
-                    Ok(line) => println!("\t\t{}", line),
-                    Err(e) => eprintln!("Error reading line: {}", e),
+                    Ok(line) => println!("\t\t{line}"),
+                    Err(e) => eprintln!("Error reading line: {e}"),
                 }
             }
         });
@@ -127,7 +127,7 @@ async fn download_simulators() -> Result<Vec<String>, ()> {
             .await
             .map_err(|_| ())?
         {
-            println!("Downloading simulator: {}", sim_url);
+            println!("Downloading simulator: {sim_url}");
             download_file(&simulator.url, &filename)
                 .await
                 .map_err(|_| ())?;
@@ -168,7 +168,7 @@ pub async fn test_simulators_after_pairing(
     };
     for simulator_filename in simulator_filenames {
         println!();
-        println!("\tSimulator tests using {}", simulator_filename);
+        println!("\tSimulator tests using {simulator_filename}");
         let _server = Server::launch(&simulator_filename);
         let noise_config = Box::new(bitbox_api::NoiseConfigNoCache {});
         let bitbox = bitbox_api::BitBox::<bitbox_api::runtime::TokioRuntime>::from_simulator(


### PR DESCRIPTION
Clippy on the beta toolchain will complain if the variables are not used directly in the string.